### PR TITLE
Fix error description formatting for NotFoundHttpException in EntityValueResolver

### DIFF
--- a/EventListener/Kernel/ApiExceptionFormatterListener.php
+++ b/EventListener/Kernel/ApiExceptionFormatterListener.php
@@ -101,7 +101,7 @@ final class ApiExceptionFormatterListener implements EventSubscriberInterface
                 $errorName = BaseErrorNames::RESOURCE_NOT_FOUND;
 
                 if (preg_match('/^(.+) object not found by the @(.+) annotation\.$/', $message)
-                    || preg_match('/^(.+) object not found by (.+). The expression (.+) returned null\.$/', $message)) {
+                    || preg_match('/^(.+) object not found by (.+)\..*$/', $message)) {
                     $message = 'resource_not_found_exception_message';
                 }
                 break;

--- a/Tests/EventListener/Kernel/ApiExceptionFormatterListenerTest.php
+++ b/Tests/EventListener/Kernel/ApiExceptionFormatterListenerTest.php
@@ -278,9 +278,17 @@ final class ApiExceptionFormatterListenerTest extends TestCase
         self::assertInstanceOf(HttpException::class, $exceptionEvent->getThrowable());
     }
 
-    public function testOnKernelExceptionWhenResourceNotFoundCausedByMapEntityAttribute(): void
+    public function resourceNotFoundExceptionMessageDataProvider(): array
     {
-        $exceptionMessage = '"App\\Entity\\Event\\Event\" object not found by \"Symfony\\Bridge\\Doctrine\\ArgumentResolver\\EntityValueResolver\". The expression \"repository.findClosedEventById(id)\" returned null.';
+        return [
+            ['"App\\Entity\\Event\\Event\" object not found by \"Symfony\\Bridge\\Doctrine\\ArgumentResolver\\EntityValueResolver\". The expression \"repository.findClosedEventById(id)\" returned null.'],
+            ['"App\\Entity\\Event\\Event" object not found by "Symfony\\Bridge\\Doctrine\\ArgumentResolver\\EntityValueResolver".'],
+        ];
+    }
+
+    /** @dataProvider resourceNotFoundExceptionMessageDataProvider */
+    public function testOnKernelExceptionWhenResourceNotFoundCausedByMapEntityAttribute(string $exceptionMessage): void
+    {
         $httpException = new NotFoundHttpException($exceptionMessage);
         $resourceNotFoundMessage = 'Resource not found';
 


### PR DESCRIPTION
The value resolver provided by symfony (`Symfony\Bridge\Doctrine\ArgumentResolver\EntityValueResolver`) throws `NotFoundHttpException` when entity is not found:

```php
if (null === $object && !$argument->isNullable()) {
    throw new NotFoundHttpException(sprintf('"%s" object not found by "%s".', $options->class, self::class).$message);
}
```

As the result, ApiExceptionFormatterListener formats response with following description:

```json
{
    "error": "resource_not_found",
    "errorDescription": "\"App\\Entity\\MyEntity\" object not found by \"Symfony\\Bridge\\Doctrine\\ArgumentResolver\\EntityValueResolver\"."
}
```

It doesn't seem to be secure this way, and it would make sense to use generic `resource_not_found_exception_message` instead.