### PR TITLE
Allow null for groups parameter in validate method

### DIFF
--- a/Validator/EntityValidator.php
+++ b/Validator/EntityValidator.php
@@ -30,7 +30,7 @@ class EntityValidator
      *
      * @throws InvalidEntityException
      */
-    public function validate(mixed $entity, Constraint|array|null $constraints = null, array $groups = null): void
+    public function validate(mixed $entity, Constraint|array|null $constraints = null, ?array $groups = null): void
     {
         $errors = $this->validator->validate($entity, $constraints, $groups);
 


### PR DESCRIPTION
Fix PHP 8.4 deprecated implicit nullable parameters