### PR TITLE
Add index on `RefreshToken` entity for `valid` field

### DIFF
--- a/Command/JWT/ClearInvalidRefreshTokensCommand.php
+++ b/Command/JWT/ClearInvalidRefreshTokensCommand.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the StfalconApiBundle.
+ *
+ * (c) Stfalcon LLC <stfalcon.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace StfalconStudio\ApiBundle\Command\JWT;
@@ -10,7 +19,6 @@ use StfalconStudio\ApiBundle\Traits\EntityManagerTrait;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\LockableTrait;
 use Symfony\Component\Console\Helper\ProgressBar;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/Command/JWT/ClearInvalidRefreshTokensCommand.php
+++ b/Command/JWT/ClearInvalidRefreshTokensCommand.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StfalconStudio\ApiBundle\Command\JWT;
+
+use StfalconStudio\ApiBundle\Command\AbstractBaseCommand;
+use StfalconStudio\ApiBundle\Repository\JWT\RefreshTokenRepository;
+use StfalconStudio\ApiBundle\Traits\EntityManagerTrait;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\LockableTrait;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(name: 'stfalcon-api-bundle:jwt:clear-refresh-token', description: 'Clear invalid refresh tokens.')]
+class ClearInvalidRefreshTokensCommand extends AbstractBaseCommand
+{
+    use EntityManagerTrait;
+    use LockableTrait;
+
+    private const DEFAULT_BATCH_SIZE = 500;
+
+    protected int $batchSize;
+
+    public function __construct(
+        private readonly RefreshTokenRepository $refreshTokenRepository,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this
+            ->addOption('sql-delete', 'sd', InputOption::VALUE_OPTIONAL, 'Sql delete', 'false')
+            ->addOption('batch-size', 'bs', InputOption::VALUE_OPTIONAL, 'Batch size', self::DEFAULT_BATCH_SIZE);
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        parent::initialize($input, $output);
+
+        $batchSizeFromInput = $input->getOption('batch-size');
+        if (!is_numeric($batchSizeFromInput)) {
+            $this->batchSize = self::DEFAULT_BATCH_SIZE;
+        } else {
+            $this->batchSize = (int) $batchSizeFromInput;
+        }
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if (!$this->lock(self::getDefaultName())) {
+            $output->writeln('The command is already running in another process.');
+
+            return self::SUCCESS;
+        }
+
+        $io = new SymfonyStyle($input, $output);
+        $io->title('Clear expired refresh token...');
+
+        $sqlDelete = 'true' === $input->getOption('sql-delete');
+
+        $count = $this->refreshTokenRepository->invalidTokensCount($this->currentDate);
+        $io->info('Total: '.$count);
+
+        if ($count > 0) {
+            $progressBar = $io->createProgressBar($count);
+
+            if ($sqlDelete) {
+                $this->delete($progressBar);
+            } else {
+                $this->remove($progressBar);
+            }
+
+            $progressBar->finish();
+            $io->newLine(2);
+        } else {
+            $io->info('There were no invalid tokens to revoke.');
+        }
+
+        $this->release();
+
+        $io->success('DONE');
+
+        return self::SUCCESS;
+    }
+
+    private function delete(ProgressBar $progressBar): void
+    {
+        do {
+            $deleted = $this->refreshTokenRepository->deleteInvalid($this->currentDate, $this->batchSize);
+            $progressBar->advance($deleted);
+        } while ($this->batchSize === $deleted);
+    }
+
+    private function remove(ProgressBar $progressBar): void
+    {
+        do {
+            $invalidTokens = $this->refreshTokenRepository->findInvalid($this->currentDate, $this->batchSize, 0);
+            $batchCount = \count($invalidTokens);
+
+            foreach ($invalidTokens as $invalidToken) {
+                $this->em->remove($invalidToken);
+            }
+
+            $this->em->flush();
+            $this->em->clear();
+
+            $progressBar->advance($batchCount);
+        } while ($this->batchSize === $batchCount);
+    }
+}

--- a/Entity/JWT/RefreshToken.php
+++ b/Entity/JWT/RefreshToken.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the StfalconApiBundle.
  *

--- a/Entity/JWT/RefreshToken.php
+++ b/Entity/JWT/RefreshToken.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 namespace StfalconStudio\ApiBundle\Entity\JWT;
 
 use Doctrine\ORM\Mapping as ORM;
-use Gesdinet\JWTRefreshTokenBundle\Entity\RefreshTokenRepository;
 use Gesdinet\JWTRefreshTokenBundle\Model\AbstractRefreshToken;
+use StfalconStudio\ApiBundle\Repository\JWT\RefreshTokenRepository;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
@@ -25,6 +25,7 @@ use Symfony\Component\Validator\Constraints as Assert;
     name: 'jwt_refresh_tokens',
     indexes: [
         new ORM\Index(columns: ['refresh_token']),
+        new ORM\Index(columns: ['valid']),
     ],
     uniqueConstraints: [
         new ORM\UniqueConstraint(columns: ['refresh_token']),

--- a/Repository/JWT/RefreshTokenRepository.php
+++ b/Repository/JWT/RefreshTokenRepository.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the StfalconApiBundle.
+ *
+ * (c) Stfalcon LLC <stfalcon.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace StfalconStudio\ApiBundle\Repository\JWT;

--- a/Repository/JWT/RefreshTokenRepository.php
+++ b/Repository/JWT/RefreshTokenRepository.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StfalconStudio\ApiBundle\Repository\JWT;
+
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+use StfalconStudio\ApiBundle\Entity\JWT\RefreshToken;
+use StfalconStudio\ApiBundle\Exception\UnexpectedValueException;
+
+class RefreshTokenRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $managerRegistry)
+    {
+        parent::__construct($managerRegistry, RefreshToken::class);
+    }
+
+    public function findInvalid(\DateTimeInterface $datetime, int $limit, int $offset = 0): array
+    {
+        /** @var RefreshToken[] $result */
+        $result = $this->createQueryBuilder('u')
+            ->where('u.valid < :datetime')
+            ->setParameter(':datetime', $datetime)
+            ->setMaxResults($limit)
+            ->setFirstResult($offset)
+            ->getQuery()
+            ->getResult();
+
+        return $result;
+    }
+
+    public function invalidTokensCount(\DateTimeInterface $datetime): int
+    {
+        $qb = $this->createQueryBuilder('u');
+        $qb->select($qb->expr()->count('u.id'))
+            ->where('u.valid < :datetime')
+            ->setParameter(':datetime', $datetime)
+        ;
+
+        $result = $qb->getQuery()->getSingleScalarResult();
+
+        if (!\is_int($result) && !\is_string($result)) {
+            throw new UnexpectedValueException('Value is not int, nor string');
+        }
+
+        return (int) $result;
+    }
+
+    public function deleteInvalid(\DateTimeInterface $datetime, int $limit): int
+    {
+        $conn = $this->getEntityManager()->getConnection();
+
+        $sql = '
+            DELETE FROM jwt_refresh_tokens
+            WHERE id IN (
+                SELECT id FROM jwt_refresh_tokens
+                WHERE valid < :datetime
+                LIMIT :limit
+            )
+        ';
+
+        return (int) $conn->executeStatement(
+            $sql,
+            [
+                'datetime' => $datetime->format('Y-m-d H:i:s'),
+                'limit' => $limit,
+            ],
+            [
+                'datetime' => \PDO::PARAM_STR,
+                'limit' => \PDO::PARAM_INT,
+            ]
+        );
+    }
+}

--- a/Resources/config/services.php
+++ b/Resources/config/services.php
@@ -33,7 +33,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->bind('iterable $filterExtractors', new TaggedIteratorArgument('stfalcon_api.filter_extractor'))
     ;
 
-    $services->load('StfalconStudio\ApiBundle\\', __DIR__.'/../../{Asset,Request,Serializer,Service,Util,Validator}/');
+    $services->load('StfalconStudio\ApiBundle\\', __DIR__.'/../../{Asset,Request,Serializer,Service,Util,Validator,Repository}/');
     $services->load('StfalconStudio\ApiBundle\EventListener\Console\\', __DIR__.'/../../EventListener/Console');
     $services->load('StfalconStudio\ApiBundle\EventListener\Kernel\\', __DIR__.'/../../EventListener/Kernel');
     $services->load('StfalconStudio\ApiBundle\EventListener\ORM\\', __DIR__.'/../../EventListener/ORM');

--- a/Tests/Command/JWT/ClearInvalidRefreshTokensCommandTest.php
+++ b/Tests/Command/JWT/ClearInvalidRefreshTokensCommandTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StfalconStudio\ApiBundle\Tests\Command\JWT;
+
+use Doctrine\ORM\EntityManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use StfalconStudio\ApiBundle\Command\JWT\ClearInvalidRefreshTokensCommand;
+use StfalconStudio\ApiBundle\Repository\JWT\RefreshTokenRepository;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Lock\LockFactory;
+use Symfony\Component\Lock\Store\SemaphoreStore;
+
+final class ClearInvalidRefreshTokensCommandTest extends TestCase
+{
+    private EntityManager|MockObject $entityManager;
+    private RefreshTokenRepository|MockObject $refreshTokenRepository;
+    private Command $command;
+    private Application $application;
+    private CommandTester $commandTester;
+
+    protected function setUp(): void
+    {
+        $this->entityManager = $this->createMock(EntityManager::class);
+        $this->refreshTokenRepository = $this->createMock(RefreshTokenRepository::class);
+
+        $command = new ClearInvalidRefreshTokensCommand($this->refreshTokenRepository);
+        $command->setEntityManager($this->entityManager);
+
+        $this->application = new Application();
+        $this->application->add($command);
+        $this->command = $this->application->find('stfalcon-api-bundle:jwt:clear-refresh-token');
+        $this->commandTester = new CommandTester($this->command);
+    }
+
+    protected function tearDown(): void
+    {
+        unset(
+            $this->entityManager,
+            $this->refreshTokenRepository,
+            $this->command,
+            $this->application,
+            $this->commandTester,
+        );
+    }
+
+    public function testLock(): void
+    {
+        $lock = (new LockFactory(new SemaphoreStore()))->createLock('stfalcon-api-bundle:jwt:clear-refresh-token');
+        $lock->acquire(true);
+
+        $result = $this->commandTester->execute(['command' => $this->command->getName()]);
+
+        self::assertSame(0, $result);
+        $output = $this->commandTester->getDisplay();
+        self::assertStringContainsString('The command is already running in another process.', $output);
+
+        $lock->release();
+    }
+
+    public function testExecuteWithNoInvalidTokensSkipsBatching(): void
+    {
+        $this->refreshTokenRepository
+            ->expects(self::once())
+            ->method('invalidTokensCount')
+            ->with(self::isInstanceOf(\DateTimeInterface::class))
+            ->willReturn(0)
+        ;
+
+        $this->refreshTokenRepository->expects(self::never())->method('deleteInvalid');
+        $this->refreshTokenRepository->expects(self::never())->method('findInvalid');
+        $this->entityManager->expects(self::never())->method('remove');
+
+        $result = $this->commandTester->execute(['command' => $this->command->getName()]);
+
+        self::assertSame(0, $result);
+        $output = $this->commandTester->getDisplay();
+        self::assertStringContainsString('Total: 0', $output);
+        self::assertStringContainsString('There were no invalid tokens to revoke.', $output);
+        self::assertStringContainsString('DONE', $output);
+    }
+
+    public function testExecuteWithSqlDeleteRunsBatchedSqlDeleteUntilPartialBatch(): void
+    {
+        $this->refreshTokenRepository
+            ->expects(self::once())
+            ->method('invalidTokensCount')
+            ->with(self::isInstanceOf(\DateTimeInterface::class))
+            ->willReturn(5)
+        ;
+
+        $this->refreshTokenRepository
+            ->expects(self::exactly(3))
+            ->method('deleteInvalid')
+            ->with(self::isInstanceOf(\DateTimeInterface::class), 2)
+            ->willReturnOnConsecutiveCalls(2, 2, 1)
+        ;
+
+        $this->refreshTokenRepository->expects(self::never())->method('findInvalid');
+        $this->entityManager->expects(self::never())->method('remove');
+
+        $result = $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            '--sql-delete' => 'true',
+            '--batch-size' => 2,
+        ]);
+
+        self::assertSame(0, $result);
+        $output = $this->commandTester->getDisplay();
+        self::assertStringContainsString('Total: 5', $output);
+        self::assertStringContainsString('DONE', $output);
+    }
+
+    public function testExecuteWithoutSqlDeleteRemovesEntitiesInBatches(): void
+    {
+        $this->refreshTokenRepository
+            ->expects(self::once())
+            ->method('invalidTokensCount')
+            ->with(self::isInstanceOf(\DateTimeInterface::class))
+            ->willReturn(3)
+        ;
+
+        $tokenA = new \stdClass();
+        $tokenB = new \stdClass();
+        $tokenC = new \stdClass();
+
+        $this->refreshTokenRepository
+            ->expects(self::exactly(2))
+            ->method('findInvalid')
+            ->with(self::isInstanceOf(\DateTimeInterface::class), 2, 0)
+            ->willReturnOnConsecutiveCalls(
+                [$tokenA, $tokenB],
+                [$tokenC],
+            )
+        ;
+
+        $this->entityManager->expects(self::exactly(3))->method('remove');
+        $this->entityManager->expects(self::exactly(2))->method('flush');
+        $this->entityManager->expects(self::exactly(2))->method('clear');
+
+        $this->refreshTokenRepository->expects(self::never())->method('deleteInvalid');
+
+        $result = $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            '--batch-size' => 2,
+        ]);
+
+        self::assertSame(0, $result);
+        $output = $this->commandTester->getDisplay();
+        self::assertStringContainsString('Total: 3', $output);
+        self::assertStringContainsString('DONE', $output);
+    }
+
+    public function testInitializeFallsBackToDefaultBatchSizeWhenOptionIsNotNumeric(): void
+    {
+        $this->refreshTokenRepository
+            ->expects(self::once())
+            ->method('invalidTokensCount')
+            ->willReturn(1)
+        ;
+
+        $this->refreshTokenRepository
+            ->expects(self::once())
+            ->method('findInvalid')
+            ->with(self::isInstanceOf(\DateTimeInterface::class), 500, 0)
+            ->willReturn([])
+        ;
+
+        $result = $this->commandTester->execute([
+            'command' => $this->command->getName(),
+            '--batch-size' => 'not-a-number',
+        ]);
+
+        self::assertSame(0, $result);
+    }
+}


### PR DESCRIPTION
## What
- Add `RefreshTokenRepository` with `invalidTokensCount`, `deleteInvalid`, `findInvalid` methods.
- Add `stfalcon-api-bundle:jwt:clear-refresh-token` console command to remove expired/invalid refresh tokens, with two modes:
  - batched SQL delete (`--sql-delete`)
  - batched entity removal via Doctrine (default), both paginated via `--batch-size` (default 500)
- Add index on `RefreshToken` entity for `valid` to speed up the invalid-tokens lookup query.

## Testing
- Unit tests for the command (batch pagination, lock behavior, sql-delete vs entity-remove modes).

## Notes
- Requires running the Doctrine migration for the new index before deploying (`bin/console doctrine:migrations:migrate`).